### PR TITLE
return 400 when auth parameter is missed.

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -139,8 +139,8 @@ TwoLeggedStrategy.prototype.authenticate = function(req) {
     }
 
     if (!params) { 
-        this.failed(req, this._challenge());
-        return this.fail(this._challenge()); 
+        this.failed(req, 400);
+        return this.fail(400); 
     }
 
     if (!params['oauth_consumer_key'] ||


### PR DESCRIPTION
modified token.js to return 400 when auth parameter is missed.

reference: http://tools.ietf.org/html/rfc5849
"The server SHOULD return a 400 (Bad Request) status code when
   receiving a request with unsupported parameters, an unsupported
   signature method, missing parameters, or duplicated protocol
   parameters."
