### PR TITLE
fixed restify trailing slash signature problem

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -195,21 +195,26 @@ TwoLeggedStrategy.prototype.authenticate = function(req) {
 
         var normalizedURL = utils.normalizeURI(url)
         , normalizedParams = utils.normalizeParams.apply(undefined, sources)
-        , base = utils.constructBaseString(req.method, normalizedURL, normalizedParams);
+        , base = utils.constructBaseString(req.method, normalizedURL, normalizedParams)
+        , baseTrailingSlash = utils.constructBaseString(req.method, normalizedURL + '/', normalizedParams);
 
         if (signatureMethod == 'HMAC-SHA1') {
             var key = consumerSecret + '&';
             if (tokenSecret) { key += tokenSecret; }
             var computedSignature = utils.hmacsha1(key, base);
+            var computedSignatureTrailingSlash = utils.hmacsha1(key, baseTrailingSlash);
 
-            if (signature !== computedSignature) {
+            if (signature !== computedSignature && signature !== computedSignatureTrailingSlash) {
 
                 // Call again but encoding the arrays with [], not as it should but so that node-oauth works
                 var normalizedParamsAlternateArrayEncoding = utils.normalizeParams.apply(undefined, sources.concat([true]));
                 var base = utils.constructBaseString(req.method, normalizedURL, normalizedParamsAlternateArrayEncoding);
+                var baseTrailingSlash = utils.constructBaseString(req.method, normalizedURL + '/', normalizedParamsAlternateArrayEncoding);
+                
                 var computedSignature = utils.hmacsha1(key, base);
+                var computedSignatureTrailingSlash = utils.hmacsha1(key, baseTrailingSlash);
 
-                if (signature !== computedSignature) {
+                if (signature !== computedSignature && signature !== computedSignatureTrailingSlash) {
                     self.failed(req, self._challenge('signature_invalid'));
                     return self.fail(self._challenge('signature_invalid'));
                 }


### PR DESCRIPTION
creates two signatures, one with / and one without and compares both to oauth-signature
