### PR TITLE
Use req.originalUrl when available

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,7 @@ exports.originalURL = function(req, defaultHost) {
                ? 'https'
                : 'http'
     , host = defaultHost || headers.host
-    , path = req.url || '';
+    , path = req.originalUrl || req.url || '';
   return protocol + '://' + host + path;
 };
 


### PR DESCRIPTION
Express manipulates req.url, making it unreliable as a representation
of the real url. If req.originalUrl is available, it should be preferred.

Resolves https://github.com/camme/passport-http-2legged-oauth/issues/3
